### PR TITLE
Use python3 instead of 2

### DIFF
--- a/bin/gild
+++ b/bin/gild
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # The main gild script that wraps the commands.
 #

--- a/bin/gild-checkout
+++ b/bin/gild-checkout
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # This script checks out a specific branch version and applies
 # all patches associated to that branch

--- a/bin/gild-clone
+++ b/bin/gild-clone
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # This script clones or updates all the vendor git repositories
 #

--- a/bin/gild-genpatch
+++ b/bin/gild-genpatch
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # This script generates the patches for a specific branch.
 #

--- a/bin/gild-get
+++ b/bin/gild-get
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # This script gets the baseline distribution archive of a specific
 # component for a specific branch

--- a/bin/gild-list
+++ b/bin/gild-list
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # This script shows all packages that can be cloned and the
 # branches that can be checked out

--- a/bin/gild-svnconv
+++ b/bin/gild-svnconv
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#! /usr/bin/env python3
 #
 # This script converts a svn vendor branch to patches in the format
 # used by gild.


### PR DESCRIPTION
This is HEAD@gild + py2 -> py3.

Tested this with adtools checking out and genpatching for gcc etc.

The issue is that py3 is becoming more prevalent in distros. py2 is still there for sure, but things like argcomplete for py2 is not available and it is a mess on to add an old repo, or find the pkg file and then install it. 