### PR TITLE
One method to allow commit IDs is to require the option --sha1. A clo…

### DIFF
--- a/bin/gild-checkout
+++ b/bin/gild-checkout
@@ -27,6 +27,7 @@ parser = argparse.ArgumentParser(description='Check out a specific branch for a 
 parser.add_argument('component', help="The name of the component to be checked out.").completer = component_completer
 parser.add_argument('branch', help="The branch as specified in the series.").completer = branch_completer
 parser.add_argument('--skip-patches', action='store_true', help="Don't apply the patches, but only checkout.")
+parser.add_argument('--sha1', action='store_true', help="The 'checkout' is a SHA1 and not a tag or branch. This will be slower to checkout.")
 autocomplete(parser)
 args = parser.parse_args()
 
@@ -63,7 +64,14 @@ if not os.path.exists(repo_path):
 	os.chdir(base)
 
 	# clone branch 'checkout' or repo_url to 'repo'
-	call(["git", "clone", repo_url, "--depth=1", "-b", checkout, "repo"])
+	if not args.sha1:
+		call(["git", "clone", repo_url, "--depth=1", "-b", checkout, "repo"])
+	else:
+		# But, if it is a commit id/sha1 then we need to pull the WHOLE
+		# thing! This increases the amount of time to clone, but since
+		# this is only done at the beginning of a new ADTOOLS
+		# cross-compilation thenperhaps it is not that big a deal.
+		call(["git", "clone", repo_url, "repo"])
 
 os.chdir(repo_path)
 


### PR DESCRIPTION
…ne directly from a SHA1 is not possible: only from a branch or tag is a clone possible. For a SHA1 it seems you need to gather the WHOLE history and then checkout the SHA1.

==

Another two options:
```
2 - allow an entry in series that specified whether it is a sha1
3 - have gild-checkout parse the 'checkout' field and check whether it is LIKELY to be a SHA1 type, eg: [0-9a-f]{40}
```